### PR TITLE
fix: breaking change detection

### DIFF
--- a/pkg/semrel/commit.go
+++ b/pkg/semrel/commit.go
@@ -24,11 +24,22 @@ type Commit struct {
 }
 
 func (c *Commit) BumpKind(cfg *Config) BumpKind {
-	if c.Attention || breakingPattern.MatchString(c.Body) {
+	if c.Attention || FilterFooters(c.Footers) {
 		return BumpMajor
 	}
+
 	return cfg.BumpKind(c.Type)
 }
+
+func FilterFooters(footers map[string]string) bool {
+	isBreakingChange := false
+	
+	for k := range c.Footers {
+		isBreakingChange = breakingPattern.MatchString(c.Footers[k])
+	}
+	return isBreakingChange
+}
+
 
 func ParseCommitMessage(message string) (*Commit, error) {
 	lines := strings.Split(message, "\n")


### PR DESCRIPTION
BREAKING CHANGE detection should 
- only match at the start of the line (^)
- match the footers of the commit instead of the body